### PR TITLE
Added module registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Modrain
+
+This module allows for registering functional namespaces along with handlers related to those namepaces.
+
+
+## Functional Namespaces
+
+Namespaces define the 

--- a/lib/angular/index.js
+++ b/lib/angular/index.js
@@ -1,0 +1,11 @@
+var modrain = require('../modrain');
+
+
+//TODO: This should probably be a separate module.
+module.exports = function() {
+  angular.module('wfm.core.modrain', []).factory('modrain', function testMediatorService() {
+    return modrain;
+  });
+
+  return 'wfm.core.modrain';
+};

--- a/lib/modrain/index.js
+++ b/lib/modrain/index.js
@@ -1,0 +1,132 @@
+var Rx = require('rx');
+var modrain = {};
+var _ = require('lodash');
+var Promise = require('bluebird');
+
+/**
+ * Represents single node module
+ */
+function ModRain(name, handlers) {
+  this.name = name;
+  // Methods that are mounted
+  this.handlers = handlers ? handlers : {};
+}
+
+/**
+ *
+ * Creating an observer for a single handler.
+ *
+ * @param namespace
+ * @param handlerName
+ * @param originalHandler
+ * @returns {Observable<T>|Rx.Observable<T>}
+ */
+function createObserver(namespace, handlerName, originalHandler) {
+
+  var ns = _.get(modrain, namespace);
+
+  var observable = Rx.Observable.create(function(observer) {
+    //Here, we are wrapping the original handler function in a function that wil call
+    //the original function and also forward the result / error to the observable
+    ns[handlerName] = function() {
+
+      //Applying the original handler with the same context.
+      return originalHandler.apply(this, arguments).then(function(handlerResult) {
+        //Emitting the result to the observer. Any observer subscribers will then also emit.
+        observer.onNext(handlerResult);
+        return Promise.resolve(handlerResult);
+      });
+    };
+
+    return function () {
+      console.log("Disposed", this);
+      //The observer is being disposed. Clean up the observer and re-assign the original function
+      ns._observers[handlerName] = undefined;
+      ns[handlerName] = originalHandler;
+    }
+  }).share();
+
+  return observable;
+}
+
+/**
+ *
+ * Mounting an observe function to observe a handler.
+ *
+ * This allows users to observe a single handler
+ *
+ * E.g. for a namespace called "users" and a handler called "create", the user can write
+ *
+ * modrain.users.observe('create');
+ *
+ * to return a standard Observable.
+ *
+ * @param namespace
+ * @private
+ */
+ModRain.prototype._mountObserve = function(namespace) {
+
+  var ns = _.get(modrain, namespace);
+
+  //Assigning the 'observe' function to the namespace.
+  ns.observe = function(handlerName) {
+    //Here we want to observe a particular handler
+
+    //If the observer already exists, then use that one
+    if (ns._observers[handlerName]) {
+      console.log("Already Exists ", handlerName, ns._observers[handlerName]);
+      return ns._observers[handlerName];
+    }
+    var originalHandler = ns[handlerName];
+
+    //We need to create a new observer for this function, we wrap the original function
+    ns._observers[handlerName] = createObserver(namespace, handlerName, originalHandler);
+
+    return ns._observers[handlerName];
+  };
+
+  ns._observers = {};
+};
+
+/**
+ * Register new method (handler) for module
+ */
+ModRain.prototype.registerHandler = function (handlerName, method) {
+  console.log("** registerHandler ", handlerName, method);
+  if (this.handlers[handlerName]) {
+    throw Error("Module handler already registered", this.name, handlerName);
+  }
+  this.handlers[handlerName] = method;
+};
+
+/**
+ *
+ * Mount module to top level. If module exist throw error
+ *
+ * @param namespace
+ * @param module
+ * @private
+ */
+ModRain.prototype._mount = function (namespace, module) {
+  _.set(modrain, namespace, module.handlers);
+  this._mountObserve(namespace);
+};
+
+/**
+ * Register new modular application module
+ *
+ * @param namespace {string} - full module namespace
+ * @param handlers {object} - an object containing
+ * @returns {*}
+ */
+modrain.registerModule = function (namespace, handlers) {
+  if (_.get(modrain, namespace)) {
+    throw Error("Module already registered for namespace: " + namespace);
+  }
+  var newModule = new ModRain(namespace,handlers);
+  newModule._mount(namespace, newModule);
+
+  return newModule;
+};
+
+module.exports = modrain;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raincatcher-modrain",
-  "version": "0.0.1",
+  "version": "0.0.1-pre.1",
   "description": "Prototype of a mediator with observables",
   "main": "./lib/angular/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "raincatcher-modrain",
+  "version": "0.0.1",
+  "description": "Prototype of a mediator with observables",
+  "main": "./lib/angular/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "bluebird": "^3.5.0",
+    "lodash": "^4.17.4",
+    "rx": "^4.1.0"
+  }
+}


### PR DESCRIPTION
# Motivation

This PR introduces the concept of users being able to `observe` handlers passed to Raincatcher.

This will allow developers to register handlers

```
var userHandlers =  {
  ..
  list: function(userToCreate) {...return Promise.resolve();....}
  ...
}

modrain.registerModule('user', userHandlers);

...

//Optional ability to observe a user list handler.
modrain.user.observe('list').subscribe(function(users) {console.log("Users were listed")});

...

//Calling the handler that returns a promise in normal way.
modrain.user.list().then(function(users) { doSomethingWithUsers(users)}).catch(handleErr);
```